### PR TITLE
All tweets page

### DIFF
--- a/backend/routes/api/modules.js
+++ b/backend/routes/api/modules.js
@@ -22,6 +22,9 @@ const getSubscribedCategories = async (user) => {
 };
 
 const getSubscribedTweets = async (user) => {
+  const userOwnTweets = await Tweet.find({author: user.id})
+          .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
+
   const subscribedUsers = await getSubscribedUsers(user)
   const subscribedUserTweets = await Tweet.find({author: {$in: subscribedUsers}})
           .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
@@ -33,7 +36,7 @@ const getSubscribedTweets = async (user) => {
     author: {$nin: user._id},
     _id: {$in: subscribedTweetIds}
   })
-  return subscribedUserTweets.concat(subscribedCategoryTweets)
+  return userOwnTweets.concat(subscribedUserTweets).concat(subscribedCategoryTweets)
 }
 
 module.exports = {

--- a/backend/routes/api/modules.js
+++ b/backend/routes/api/modules.js
@@ -22,13 +22,16 @@ const getSubscribedCategories = async (user) => {
 };
 
 const getSubscribedTweets = async (user) => {
-  const userOwnTweets = await Tweet.find({author: user.id})
+  const userOwnTweets = await Tweet.find({
+                                  author: user.id,
+                                  date: { $lt: new Date() }
+                                })
           .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
-
+  
   const subscribedUsers = await getSubscribedUsers(user)
   const subscribedUserTweets = await Tweet.find({author: {$in: subscribedUsers}})
           .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
-  
+          
   const subscribedCategories = await getSubscribedCategories(user);
   const subscribedPostCategories = await PostCategory.find({category: {$in: subscribedCategories}})
   const subscribedTweetIds = subscribedPostCategories.map(postCat => postCat.post)
@@ -36,6 +39,7 @@ const getSubscribedTweets = async (user) => {
     author: {$nin: user._id},
     _id: {$in: subscribedTweetIds}
   })
+          .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
   return userOwnTweets.concat(subscribedUserTweets).concat(subscribedCategoryTweets)
 }
 

--- a/backend/routes/api/tweets.js
+++ b/backend/routes/api/tweets.js
@@ -74,17 +74,15 @@ router.get('/', requireUser, async function(req, res, next) {
   // });
   try {
     const currentUser = req.user
-    const tweets = await getSubscribedTweets(currentUser)
+    const subscribedTweets = await getSubscribedTweets(currentUser)
                               // .populate("author", "_id username profileImageUrl twitterHandle instagramHandle")
-
-    const tweetsWithCategories = await Promise.all(tweets.map(async tweet => {
+    const tweetsWithCategories = await Promise.all(subscribedTweets.map(async tweet => {
           tweet = await addCategoriesAndImagesToTweet(tweet)
           return tweet;
     }));
 
-    const tweetObjects = tweetArrayToObject(tweetsWithCategories)
-                          
-    return res.json(tweetObjects);
+    const subscribedTweetObjects = tweetArrayToObject(tweetsWithCategories)
+    return res.json(subscribedTweetObjects);
   }
   catch(err) {
     return res.json([]);

--- a/backend/routes/api/users.js
+++ b/backend/routes/api/users.js
@@ -44,7 +44,7 @@ router.post('/register', singleMulterUpload("image"), validateRegisterInput,asyn
 
   if (user) {
     const err = new Error("Validation Error");
-    err.statusCode = 400;
+    err.statusCode = 422;
     const errors = {};
     if (user.email === req.body.email) {
       errors.email = "A user has already registered with this email";
@@ -89,7 +89,8 @@ router.post('/login', singleMulterUpload(''), async (req, res, next) => {
     if (!user) {
       const err = new Error('Invalid credentials');
       err.statusCode = 422;
-      err.errors = { email: "Invalid credentials" };
+      err.email= true;
+      err.password= true;
       return next(err);
     }
     return res.json(await loginUser(user));

--- a/backend/routes/api/users.js
+++ b/backend/routes/api/users.js
@@ -88,7 +88,7 @@ router.post('/login', singleMulterUpload(''), async (req, res, next) => {
     if (err) return next(err);
     if (!user) {
       const err = new Error('Invalid credentials');
-      err.statusCode = 400;
+      err.statusCode = 422;
       err.errors = { email: "Invalid credentials" };
       return next(err);
     }

--- a/frontend/src/components/BigCalendar/BarChart.js
+++ b/frontend/src/components/BigCalendar/BarChart.js
@@ -77,7 +77,7 @@ const BarChart = ({userTweets}) => {
         })
     }, [basicChartData.length])
 
-    console.log(chartData)
+    // console.log(chartData)
 
     const option={
         indexAxis:'y',

--- a/frontend/src/components/BigCalendar/BigCalendar.css
+++ b/frontend/src/components/BigCalendar/BigCalendar.css
@@ -91,3 +91,24 @@
     width: 100% !important;
     height: 100% !important;
 }
+
+
+
+/* Change cursor to grab on hover over the .fc-event */
+.fc-event:hover, .fc-event-draggable:hover {
+    cursor: grab;
+}
+
+/*I can't figure out why, but as soon as the mouse moves, the :active => cursor: grabbing gets overridden by the :hover effect above*/
+.fc-event:active, .fc-event-draggable:active, .fc-event-start:active, .fc-event-resizable:active, .fc-event-past:active, .fc-daygrid-event:active, 
+.fc-daygrid-dot-event:active, .event-div:active, .fc-event-end:active {
+    cursor: grabbing !important;
+    position: relative;
+    z-index: 2;
+}
+
+/* /*this is a decent alternative/*
+.fc-event, .fc-event-draggable, .fc-event-start, .fc-event-resizable, .fc-event-past, .fc-daygrid-event, 
+.fc-daygrid-dot-event, .event-div, .fc-event-end {
+    cursor: move !important;
+} */

--- a/frontend/src/components/Calendar/Calendar.css
+++ b/frontend/src/components/Calendar/Calendar.css
@@ -84,4 +84,7 @@
     background-color: #1a252f;
 }
 
+.fc-daygrid-event-harness {
+    cursor: pointer;
+}
 

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -19,7 +19,7 @@ function NavBar () {
           
           <Link to={'/profile'}><i className="fa-solid fa-user fa-2xl" style={{color: "#f6f4eb"}}></i></Link>
           <Link to={'/tweets/new'}><i className="fa-solid fa-circle-plus fa-2xl" style={{color: "#f6f4eb"}}></i></Link>
-          <Link to={'/calendar'}><i class="fa-solid fa-calendar-days fa-2xl" style={{color: "#f6f4eb"}}></i></Link>
+          <Link to={'/calendar'}><i className="fa-solid fa-calendar-days fa-2xl" style={{color: "#f6f4eb"}}></i></Link>
           <Link to={'/about'}><i className="fa-solid fa-info fa-2xl" style={{color: "#f6f4eb"}}></i></Link>
           <button className="navbarLogout" onClick={logoutUser}>Logout</button>
         </div>
@@ -37,7 +37,7 @@ function NavBar () {
   return (
     <>
       <div className='navbarContainer'>
-        <Link to="/profile"><img className="navbarLogo" src='/assets/images/SocialQOffWhite.png' alt='socialQlogo'></img></Link>
+        <Link to="/tweets"><img className="navbarLogo" src='/assets/images/SocialQOffWhite.png' alt='socialQlogo'></img></Link>
         
         { getLinks() }
       </div>

--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -12,7 +12,7 @@ function Profile () {
   const dispatch = useDispatch();
   const currentUser = useSelector(state => state.session.user);
   const userTweets = useSelector(state => Object.values(state.tweets.user))
-  const tweetsSortedByDate = userTweets?.map(tweet => tweet).sort((a,b) => a.date - b.date);
+  const tweetsSortedByDate = userTweets?.map(tweet => tweet).sort((a,b) => new Date(b.date) - new Date(a.date));
 
 
   
@@ -21,88 +21,91 @@ function Profile () {
     return () => dispatch(clearTweetErrors());
   }, [currentUser, dispatch]);
 
-  if (userTweets.length === 0) {
-    return (
-      <>
-      <div className='loading-div'>
-        <LoadingPage type={'spinningBubbles'} color={'#91C8E4'} />
-      </div>
+  // if (userTweets.length === 0) {
+  //   return (
+  //     <>
+  //     <div className='loading-div'>
+  //       <LoadingPage type={'spinningBubbles'} color={'#91C8E4'} />
+  //     </div>
         
-      </>
-    )
-  } else {
+  //     </>
+  //   )
+  // } else {
   
     return (
       <>
         <NavBar/>
         <div id='editModal' className='hide-edit-modal'></div>
-        <div className='profile-container'>
-
-          <div className='left-container'>
-          {currentUser.profileImageUrl ? 
-            <img className="profile-image-main" src={currentUser.profileImageUrl} alt="profile"/> :
-            undefined
-          }
-            <h2 className='currentUserProfile'>{currentUser.username}'s Profile</h2>
-            <div className='profile-subs-container'>
-              <h1 className='subs-header'>Subscribers</h1>
-              <br/>
-              <p className='subs'>@Peter-GPT</p>
-              <br/>
-              <p className='subs'>@Amin-B-RightBack</p>
-              <br/>
-              <p className='subs'>@SteveTheDream</p>
-              <br/>
-              <p className='subs'>@ClarenceS</p>
-              <br/>
-              <p className='subs'>@MaxCarp</p>
-              <br/>
-              <p className='subs'>@HarveyS</p>
-              <br/>
-              <p className='subs'>@TheoNeo23</p>
-              <br/>
-              <p className='subs'>@JoeRandazzleme</p>
-              <br/>
-              <p className='subs'>@HulkHoganBrother</p>
-              <br/>
-              <p className='subs'>@Cher</p>
-            {/* {userSubs && userSubs.map(subscriber => (   
-                <p>{subscriber.author.twitterHandle}</p>
-                ))} */}
-            </div>
-          </div>
-
-          <div className='middle-container'>
-            <h2 className='currentUserHeader'>{currentUser.username}'s Tweets</h2>
-
-            <div className='tweet-container'>
-              {tweetsSortedByDate.map(tweet => (
-                <div className='individual-tweet'>
-                  <TweetBox
-                    key={tweet._id}
-                    tweet={tweet}
-                    alreadyExists={true}
-                  />
+        {userTweets.length === 0 ? 
+            (<div className='loading-div'>
+              <LoadingPage type={'spinningBubbles'} color={'#91C8E4'} />
+            </div>) 
+            :
+            (<div className='profile-container'>
+                <div className='left-container'>
+                  {currentUser.profileImageUrl ? 
+                      <img className="profile-image-main" src={currentUser.profileImageUrl} alt="profile"/> :
+                        undefined
+                  }
+                  <h2 className='currentUserProfile'>{currentUser.username}'s Profile</h2>
+                  <div className='profile-subs-container'>
+                  <h1 className='subs-header'>Subscribers</h1>
+                  <br/>
+                  <p className='subs'>@Peter-GPT</p>
+                  <br/>
+                  <p className='subs'>@Amin-B-RightBack</p>
+                  <br/>
+                  <p className='subs'>@SteveTheDream</p>
+                  <br/>
+                  <p className='subs'>@ClarenceS</p>
+                  <br/>
+                  <p className='subs'>@MaxCarp</p>
+                  <br/>
+                  <p className='subs'>@HarveyS</p>
+                  <br/>
+                  <p className='subs'>@TheoNeo23</p>
+                  <br/>
+                  <p className='subs'>@JoeRandazzleme</p>
+                  <br/>
+                  <p className='subs'>@HulkHoganBrother</p>
+                  <br/>
+                  <p className='subs'>@Cher</p>
+                  {/* {userSubs && userSubs.map(subscriber => (   
+                      <p>{subscriber.author.twitterHandle}</p>
+                      ))} */}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
 
-          <div className='right-container'>
-            <div className='theos-calendar-container'>
-             < Calendar />
-            </div>
+              <div className='middle-container'>
+                <h2 className='currentUserHeader'>{currentUser.username}'s Tweets</h2>
 
-            <h1 className='stats-header'>{currentUser.username}'s Stats</h1>
-            <div className='stats-container'>
-              <BarChart userTweets={userTweets} />
-            </div>
-          </div>
+                <div className='tweet-container'>
+                  {tweetsSortedByDate.map(tweet => (
+                    <div className='individual-tweet'>
+                      <TweetBox
+                        key={tweet._id}
+                        tweet={tweet}
+                        alreadyExists={true}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
 
-       </div>
+              <div className='right-container'>
+                <div className='theos-calendar-container'>
+                < Calendar />
+                </div>
+
+                <h1 className='stats-header'>{currentUser.username}'s Stats</h1>
+                <div className='stats-container'>
+                  <BarChart userTweets={userTweets} />
+                </div>
+              </div>
+
+        </div>)}
       </>
-    );
-              }
+    );           
 }
 
 export default Profile;

--- a/frontend/src/components/SessionForms/LoginForm.js
+++ b/frontend/src/components/SessionForms/LoginForm.js
@@ -8,7 +8,8 @@ import { Link } from 'react-router-dom/cjs/react-router-dom.min';
 function LoginForm () {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  // const errors = useSelector(state => state.errors.session);
+  const [emailExists, setEmailExists] = useState('');
+  const [passwordExists, setPasswordExists] = useState('');
   const [errorMessage, setErrorMessage] = useState(null)
   const [emailErrors, setEmailErrors] = useState(false)
   const [passwordErrors, setPasswordErrors] = useState(false)
@@ -28,7 +29,6 @@ function LoginForm () {
   const handleSubmit = async (e) => {
     e.preventDefault();
     const resErrors = await dispatch(login({ email, password })); 
-    debugger
     if (resErrors.statusCode === 422) {
       setErrorMessage(resErrors.message)
       setEmailErrors(true)
@@ -54,35 +54,39 @@ function LoginForm () {
           <div className="errors">{errorMessage}</div>
           
           <label>
-            <p className={`inputHeader ${emailErrors ? 'errors-text' : ''}`}>Email</p>
+            <p className={`inputHeader ${(emailExists && !email.length) || emailErrors ? 'errors-text' : ''}`}>Email</p>
           
             <input 
-              className={`formInput ${emailErrors ? 'errors-div' : ''}`}
+              className={`formInput ${(emailExists && !email.length) || emailErrors ? 'errors-div' : ''}`}
               type="text"
               value={email}
-              onChange={(e)=>{update('email')(e); setEmailErrors(false)}}
+              onBlur={()=>setEmailExists(true)}
+              onChange={(e)=>{update('email')(e); setEmailExists(true); setEmailErrors(false)}}
               placeholder="Email"
             />
           </label>
 
-          {/* <div className="errors">{errors?.password}</div> */}
+          <div className="signupErrors">{emailExists && !email.length ? 'Email can\'t be blank' : ''}</div>
 
           <label>
-            <p className={`inputHeader ${passwordErrors ? 'errors-text' : ''}`}>Password</p>
+            <p className={`inputHeader ${(passwordExists && !password.length) || passwordErrors ? 'errors-text' : ''}`}>Password</p>
           
             <input 
-              className={`formInput ${passwordErrors ? 'errors-div' : ''}`}
+              className={`formInput ${(passwordExists && !password.length) || passwordErrors ? 'errors-div' : ''}`}
               type="password"
               value={password}
+              onBlur={()=>setPasswordExists(true)}
               onChange={(e)=>{update('password')(e); setPasswordErrors(false)}}
               placeholder="Password"
             />
           </label>
 
+          <div className="signupErrors">{passwordExists && !password.length ? 'Password can\'t be blank' : ''}</div>
+
           <br/>
 
           <input
-            className='loginButton'
+            className={`loginButton ${email && password ? '' : 'auth-greyed-out'}`}
             type="submit"
             value="Log In"
             disabled={!email || !password}

--- a/frontend/src/components/SessionForms/LoginForm.js
+++ b/frontend/src/components/SessionForms/LoginForm.js
@@ -8,7 +8,10 @@ import { Link } from 'react-router-dom/cjs/react-router-dom.min';
 function LoginForm () {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const errors = useSelector(state => state.errors.session);
+  // const errors = useSelector(state => state.errors.session);
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [emailErrors, setEmailErrors] = useState(false)
+  const [passwordErrors, setPasswordErrors] = useState(false)
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -22,9 +25,16 @@ function LoginForm () {
     return e => setState(e.currentTarget.value);
   }
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    dispatch(login({ email, password })); 
+    const resErrors = await dispatch(login({ email, password })); 
+    debugger
+    if (resErrors.statusCode === 422) {
+      setErrorMessage(resErrors.message)
+      setEmailErrors(true)
+      setPasswordErrors(true)
+    }
+    
   }
 
   const handleDemoLogin = (e) => {
@@ -41,30 +51,30 @@ function LoginForm () {
           <img className="socialQBlackLogo" src='/assets/images/SocialQBlackLogo.png' alt='socialQlogo'></img>
           <br/>
 
-          <div className="errors">{errors?.email}</div>
+          <div className="errors">{errorMessage}</div>
           
           <label>
-            <p className='inputHeader'>Email</p>
+            <p className={`inputHeader ${emailErrors ? 'errors-text' : ''}`}>Email</p>
           
             <input 
-              className='formInput'
+              className={`formInput ${emailErrors ? 'errors-div' : ''}`}
               type="text"
               value={email}
-              onChange={update('email')}
+              onChange={(e)=>{update('email')(e); setEmailErrors(false)}}
               placeholder="Email"
             />
           </label>
 
-          <div className="errors">{errors?.password}</div>
+          {/* <div className="errors">{errors?.password}</div> */}
 
           <label>
-            <p className='inputHeader'>Password</p>
+            <p className={`inputHeader ${passwordErrors ? 'errors-text' : ''}`}>Password</p>
           
             <input 
-              className='formInput'
+              className={`formInput ${passwordErrors ? 'errors-div' : ''}`}
               type="password"
               value={password}
-              onChange={update('password')}
+              onChange={(e)=>{update('password')(e); setPasswordErrors(false)}}
               placeholder="Password"
             />
           </label>
@@ -85,9 +95,9 @@ function LoginForm () {
           > Demo Log In</button>
           
           <div className='signupLinkContainer'>
-            <p>Don't have an account?</p>
+            <p>Don't have an account?</p> <br/>
           
-            <Link to="/signup"className="sinupLink">Sign Up</Link>
+            <p><Link to="/signup"className="sinupLink">Sign Up</Link></p>
           </div>
 
         </form>

--- a/frontend/src/components/SessionForms/SessionForm.css
+++ b/frontend/src/components/SessionForms/SessionForm.css
@@ -69,6 +69,10 @@
 
 }
 
+.sign-up-greyed-out {
+    background-color: grey;
+}
+
 .loginButton:hover{
     background-color: gray;
     cursor: pointer;
@@ -85,16 +89,29 @@
 
 
 .errors{
-    margin-top: 20px;
+    position: absolute;
+    margin-top: 0px;
     margin-left: 110px;
     color: maroon;
     font-weight: bold;
     /* font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; */
 }
 
-.passwordErrors{
-    margin-top: 15px;
+.errors-text {
+    color: maroon;
+}
+
+.errors-div {
+    border: 1px solid maroon;
+    box-shadow: 0 0 0 1px rgb(117, 97, 97),0 1px 2px rgba(15,17,17,.15) inset;
+    padding-inline: 4px;
+}
+
+.signupErrors{
+    /* border: 1px solid black; */
+    /* margin-top: 5px; */
     margin-left: 67px;
+    height: 1.2em;
     color: maroon;
     font-size: 12px;
     font-weight: bold;

--- a/frontend/src/components/SessionForms/SessionForm.css
+++ b/frontend/src/components/SessionForms/SessionForm.css
@@ -66,16 +66,22 @@
     color: white;
     font-size: 20px;
     /* font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; */
-
-}
-
-.sign-up-greyed-out {
-    background-color: grey;
+    transition: background-color 100ms ease-in-out;
 }
 
 .loginButton:hover{
     background-color: gray;
     cursor: pointer;
+}
+
+.auth-greyed-out {
+    background-color: gray;
+    opacity: .6;
+}
+
+.auth-greyed-out:hover {
+    cursor: default;
+    opacity: .6;
 }
 
 .signupLinkContainer{

--- a/frontend/src/components/SessionForms/SignupForm.js
+++ b/frontend/src/components/SessionForms/SignupForm.js
@@ -13,17 +13,20 @@ function SignupForm () {
   const [emailExists, setEmailExists] = useState(false);
   const [fullNameExists,setFullNameExists] = useState(false);
   const [passwordExists, setPasswordExists] = useState(false);
+  const [password2Exists, setPassword2Exists] = useState(false);
   const [image, setImage] = useState(null)
   const [errors, setErrors] = useState(null)
   const [emailErrors, setEmailErrors] = useState(false);
   const [usernameErrors, setUsernameErrors] = useState(false);
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    return () => {
-      dispatch(clearSessionErrors());
-    };
-  }, [dispatch]);
+  function validateEmail(email) {
+    // Define the regex pattern for email validation
+    const pattern = /^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z]+$/;
+  
+    // Test the email against the pattern
+    return pattern.test(email);
+  }
 
   const update = field => {
     let setState;
@@ -77,14 +80,14 @@ function SignupForm () {
                 className={`formInput ${(emailExists && !email.length) || emailErrors ? 'errors-div' : ''}`}
                 type="text"
                 value={email}
-                onChange={e=>{update('email')(e);setEmailExists(true); setEmailErrors(false)}}
+                onChange={e=>{update('email')(e);setEmailExists(true); setEmailErrors(false); validateEmail(email) ? setEmailErrors(false) : setEmailErrors(true)}}
                 placeholder="Email"
               />
             </label>
             <div className="signupErrors">{errors?.email}</div>
 
             <div className="signupErrors">
-              <p>{emailExists && !email.length && 'Email can\'t be blank'}</p><br/>
+              <p>{emailExists && !email.length && 'Email can\'t be blank'} {email && !validateEmail(email) && 'Invalid email address'}</p>
             </div>
             
             <label>
@@ -124,13 +127,13 @@ function SignupForm () {
                 className={`formInput ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-div' : ''}`}
                 type="password"
                 value={password2}
-                onChange={update('password2')}
+                onChange={e=>{update('password2')(e); setPassword2Exists(true)}}
                 placeholder="Confirm Password"
               />
             </label>
 
             <div className="signupErrors">
-              <p>{password2 && password !== password2 && 'Passwords must match'}</p>
+              <p>{password2Exists && password !== password2 && 'Passwords must match'}</p>
             </div>
 
             <p className='inputHeader'>Profile Picture</p>

--- a/frontend/src/components/SessionForms/SignupForm.js
+++ b/frontend/src/components/SessionForms/SignupForm.js
@@ -9,8 +9,14 @@ function SignupForm () {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [password2, setPassword2] = useState('');
+
+  const [emailExists, setEmailExists] = useState(false);
+  const [fullNameExists,setFullNameExists] = useState(false);
+  const [passwordExists, setPasswordExists] = useState(false);
   const [image, setImage] = useState(null)
-  const errors = useSelector(state => state.errors.session);
+  const [errors, setErrors] = useState(null)
+  const [emailErrors, setEmailErrors] = useState(false);
+  const [usernameErrors, setUsernameErrors] = useState(false);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -44,7 +50,7 @@ function SignupForm () {
 
   const updateFile = e => setImage(e.target.files[0]);
 
-  const handleSubmit = e => {
+  const handleSubmit = async e => {
     e.preventDefault();
     const user = {
       email,
@@ -53,7 +59,10 @@ function SignupForm () {
       image
     };
 
-    dispatch(signup(user)); 
+    const resErrors = await dispatch(signup(user)); 
+    setErrors(resErrors.errors);
+    setEmailErrors(true);
+    setUsernameErrors(true);
   }
 
   return (
@@ -62,53 +71,57 @@ function SignupForm () {
           
             <img className="socialQBlackLogoSignUp" src='/assets/images/SocialQBlackLogo.png' alt='socialQlogo'></img>
             
-            <div className="errors">{errors?.email}</div>
-            
             <label>
-              <p className='inputHeader'>Email</p>
+              <p className={`inputHeader ${(emailExists && !email.length) || emailErrors ? 'errors-text' : ''}`}>Email</p>
               <input 
-                className='formInput'
+                className={`formInput ${(emailExists && !email.length) || emailErrors ? 'errors-div' : ''}`}
                 type="text"
                 value={email}
-                onChange={update('email')}
+                onChange={e=>{update('email')(e);setEmailExists(true); setEmailErrors(false)}}
                 placeholder="Email"
               />
             </label>
+            <div className="signupErrors">{errors?.email}</div>
 
-            <div className="errors">{errors?.username}</div>
+            <div className="signupErrors">
+              <p>{emailExists && !email.length && 'Email can\'t be blank'}</p><br/>
+            </div>
             
             <label>
-              <p className='inputHeader'>Full Name</p>
+              <p className={`inputHeader ${(fullNameExists && !username.length) || usernameErrors ? 'errors-text' : ''}`}>Full Name</p>
               <input 
-                className='formInput'
+                className={`formInput ${(fullNameExists && !username.length) || usernameErrors ? 'errors-div' : ''}`}
                 type="text"
                 value={username}
-                onChange={update('username')}
+                onChange={e=>{update('username')(e);setFullNameExists(true); setUsernameErrors(false)}}
                 placeholder="Full Name"
               />
             </label>
 
-            <div className="errors">{errors?.password}</div>
+            <div className="signupErrors">{errors?.username}</div>
+            <div className="signupErrors">
+              <p>{fullNameExists && !username.length && 'Full Name can\'t be blank'}</p><br/>
+            </div>
             
             <label>
-              <p className='inputHeader'>Password</p>
+              <p className={`inputHeader ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-text' : ''}`}>Password</p>
               <input 
-                className='formInput'
+                className={`formInput ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-div' : ''}`}
                 type="password"
                 value={password}
-                onChange={update('password')}
+                onChange={(e)=>{update('password')(e); setPasswordExists(true)}}
                 placeholder="Password"
               />
             </label>
 
-            <div className="passwordErrors">
-              {password !== password2 && 'Confirm Password field must match'}
+            <div className="signupErrors">
+              <p>{passwordExists && password.length < 8 && 'Password must 8 or more characters'}</p><br/>
             </div>
 
             <label>
-              <p className='inputHeader'>Confirm Password</p>
+              <p className={`inputHeader ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-text' : ''}`}>Confirm Password</p>
               <input 
-                className='formInput'
+                className={`formInput ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-div' : ''}`}
                 type="password"
                 value={password2}
                 onChange={update('password2')}
@@ -116,13 +129,17 @@ function SignupForm () {
               />
             </label>
 
+            <div className="signupErrors">
+              <p>{password2 && password !== password2 && 'Passwords must match'}</p>
+            </div>
+
             <p className='inputHeader'>Profile Picture</p>
             <label>
               <input  className="formInput"type="file" accept=".jpg, .jpeg, .png" onChange={updateFile} />
             </label>
 
             <input
-              className='loginButton'
+              className={`loginButton ${email && username && password && password === password2 ? '' : 'sign-up-greyed-out'}`}
               type="submit"
               value="Sign Up"
               disabled={!email || !username || !password || password !== password2}

--- a/frontend/src/components/SessionForms/SignupForm.js
+++ b/frontend/src/components/SessionForms/SignupForm.js
@@ -11,7 +11,7 @@ function SignupForm () {
   const [password2, setPassword2] = useState('');
 
   const [emailExists, setEmailExists] = useState(false);
-  const [fullNameExists,setFullNameExists] = useState(false);
+  const [usernameExists,setUsernameExists] = useState(false);
   const [passwordExists, setPasswordExists] = useState(false);
   const [password2Exists, setPassword2Exists] = useState(false);
   const [image, setImage] = useState(null)
@@ -80,7 +80,8 @@ function SignupForm () {
                 className={`formInput ${(emailExists && !email.length) || emailErrors ? 'errors-div' : ''}`}
                 type="text"
                 value={email}
-                onChange={e=>{update('email')(e);setEmailExists(true); setEmailErrors(false); validateEmail(email) ? setEmailErrors(false) : setEmailErrors(true)}}
+                onBlur={()=>setEmailExists(true)}
+                onChange={e=>{update('email')(e); setEmailErrors(false); validateEmail(email) ? setEmailErrors(false) : setEmailErrors(true)}}
                 placeholder="Email"
               />
             </label>
@@ -91,19 +92,20 @@ function SignupForm () {
             </div>
             
             <label>
-              <p className={`inputHeader ${(fullNameExists && !username.length) || usernameErrors ? 'errors-text' : ''}`}>Full Name</p>
+              <p className={`inputHeader ${(usernameExists && !username.length) || usernameErrors ? 'errors-text' : ''}`}>Full Name</p>
               <input 
-                className={`formInput ${(fullNameExists && !username.length) || usernameErrors ? 'errors-div' : ''}`}
+                className={`formInput ${(usernameExists && !username.length) || usernameErrors ? 'errors-div' : ''}`}
                 type="text"
                 value={username}
-                onChange={e=>{update('username')(e);setFullNameExists(true); setUsernameErrors(false)}}
+                onBlur={()=>setUsernameExists(true)}
+                onChange={e=>{update('username')(e); setUsernameErrors(false)}}
                 placeholder="Full Name"
               />
             </label>
 
             <div className="signupErrors">{errors?.username}</div>
             <div className="signupErrors">
-              <p>{fullNameExists && !username.length && 'Full Name can\'t be blank'}</p><br/>
+              <p>{usernameExists && !username.length && 'Full Name can\'t be blank'}</p><br/>
             </div>
             
             <label>
@@ -112,7 +114,8 @@ function SignupForm () {
                 className={`formInput ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-div' : ''}`}
                 type="password"
                 value={password}
-                onChange={(e)=>{update('password')(e); setPasswordExists(true)}}
+                onBlur={()=>setPasswordExists(true)}
+                onChange={(e)=>update('password')(e)}
                 placeholder="Password"
               />
             </label>
@@ -127,13 +130,14 @@ function SignupForm () {
                 className={`formInput ${passwordExists && (password.length < 8 || password !== password2) ? 'errors-div' : ''}`}
                 type="password"
                 value={password2}
-                onChange={e=>{update('password2')(e); setPassword2Exists(true)}}
+                onBlur={()=>setPasswordExists(true)}
+                onChange={e=>update('password2')(e)}
                 placeholder="Confirm Password"
               />
             </label>
 
             <div className="signupErrors">
-              <p>{password2Exists && password !== password2 && 'Passwords must match'}</p>
+              <p>{passwordExists && password !== password2 && 'Passwords must match'}</p>
             </div>
 
             <p className='inputHeader'>Profile Picture</p>
@@ -142,7 +146,7 @@ function SignupForm () {
             </label>
 
             <input
-              className={`loginButton ${email && username && password && password === password2 ? '' : 'sign-up-greyed-out'}`}
+              className={`loginButton ${email && username && password && password === password2 ? '' : 'auth-greyed-out'}`}
               type="submit"
               value="Sign Up"
               disabled={!email || !username || !password || password !== password2}

--- a/frontend/src/components/Tweets/SelectEditDateCalendar.css
+++ b/frontend/src/components/Tweets/SelectEditDateCalendar.css
@@ -48,9 +48,9 @@
     background-color: #4682A9;
 }
 
-.fc-event-draggable {
+/* .fc-event-draggable {
     cursor: pointer;
-}
+} */
 
 .fc-day {
     cursor: default;

--- a/frontend/src/components/Tweets/Tweets.css
+++ b/frontend/src/components/Tweets/Tweets.css
@@ -1,0 +1,14 @@
+.tweet-feed-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    /* justify-content: center; */
+    
+}
+.middle-container {
+    /* margin-left: 10em; */
+    /* display: flex; */
+    /* align-items: center; */
+    /* justify-content: center; */
+}

--- a/frontend/src/components/Tweets/Tweets.js
+++ b/frontend/src/components/Tweets/Tweets.js
@@ -4,12 +4,15 @@ import { clearTweetErrors, fetchTweets } from '../../store/tweets';
 import TweetBox from './TweetBox';
 import Calendar from "../Calendar/Calendar";
 import NavBar from '../NavBar/NavBar';
+import LoadingPage from '../LoadingPage';
 import "./Tweets.css";
 
 function Tweets () {
   const dispatch = useDispatch();
-  const tweets = useSelector(state => Object.values(state.tweets.all));
-  const tweetsSortedByDate = tweets?.sort((a,b) => a.date - b.date);
+  const currentUser = useSelector(state => state.session.user);
+  const tweetFeed = useSelector(state => state.tweets.subscribed ? Object.values(state.tweets.subscribed) : []);
+  const tweetsSortedByDate = tweetFeed?.sort((a,b) => new Date(b.date) - new Date(a.date));
+
   useEffect(() => {
     dispatch(fetchTweets());
     return () => dispatch(clearTweetErrors());
@@ -21,9 +24,29 @@ function Tweets () {
     <>
       {/* <h2>Welcome</h2> */}
       <NavBar/>
-      {/* {tweetsSortedByDate?.map(tweet => (
-        <TweetBox key={tweet._id} tweet={tweet} />
-      ))} */}
+      <section className='tweet-feed-container'>
+          <div className='middle-container'>
+                <h2 className='currentUserHeader'>{currentUser.username}'s Feed</h2>
+                {tweetFeed.length === 0 ? 
+                  (<div className='loading-div'>
+                    <LoadingPage type={'spinningBubbles'} color={'#91C8E4'} />
+                  </div>) 
+                  :
+                  (<div className='tweet-feed-container'>
+                    {tweetsSortedByDate.map(tweet => (
+                      <div className='individual-tweet'>
+                        <TweetBox
+                          key={tweet._id}
+                          tweet={tweet}
+                          alreadyExists={true}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  )
+                }
+          </div>
+      </section>
     </>
   );
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,6 +7,9 @@ import { BrowserRouter } from 'react-router-dom';
 import configureStore from './store/store';
 
 let store = configureStore({});
+if (process.env.NODE_ENV !== "production") {
+  window.store = store;
+}
 
 function Root() {
   return (

--- a/frontend/src/store/session.js
+++ b/frontend/src/store/session.js
@@ -49,8 +49,9 @@ const startSession = (userInfo, route) => async dispatch => {
     return dispatch(receiveCurrentUser(user));
   } catch(err) {
     const res = await err.json();
-    if (res.statusCode === 400) {
-      return dispatch(receiveErrors(res.errors));
+    if (res.statusCode === 422) {
+      // return dispatch(receiveErrors(res.errors));
+      return res
     }
   }
 };

--- a/frontend/src/store/tweets.js
+++ b/frontend/src/store/tweets.js
@@ -150,7 +150,7 @@ const tweetsReducer = (state = { all: {}, user: {}, new: undefined }, action) =>
     const newState = {...state}
     switch(action.type) {
       case RECEIVE_TWEETS:
-        return { ...state, all: action.tweets, new: undefined};
+        return { ...state, subscribed: action.tweets, new: undefined};
       case RECEIVE_USER_TWEETS:
         return { ...state, subscribed: action.tweets.subscribed, user: action.tweets.user, new: undefined};
       case RECEIVE_NEW_TWEET:


### PR DESCRIPTION
Navbar
- Social Q logo links to 'tweets' (can't figure out how Theo got those FA icons in there, I don't see where they come from)

All Tweets Page
- fixed controller to return as "subscribed tweets": all user tweets in the past, all subscribed users' tweets, all subscribed category tweets. fixed the 'populate' in subscribed category tweets so that user's photo and username are returned for display
- display those on '/tweets'

Signup errors
- email must be present and fit regex pattern
- password must be present and >=8 chars
- moved and resized pw/confirm pw errors
- on submit, email/username cant be taken
- when errors are noticed for any field, the div highlights red and text turns red. on fixing errors, the red highlights go away

Signin errors:
- onBlur, it checks that email and pw are present, otherwise highlights red for errors and says "must be present"
- on incorrect submission, 'invalid credentials' div changed to position: absolute so the other divs don't move down, divs are highlighted red, and then onChange, the red highlights are taken away (signifying the user is correcting their errors)

Profile:
- fixed incorrect date sorting
- changed cursor to pointer on calendar events. we might also consider changing them to some 'delete' icon. nothing built in with default cursors, but easy to have a custom one, maybe something from here: https://icons8.com/icons/set/delete

Big Calendar:
- tried to change cursor to open hand 'grab' on :hover, closed hand 'grabbing' on :active, but can't solve a bug where it changes back to 'grab' when the mouse starts moving. v frustrating, it would look really good if i could get it to work! other option in the BigCalendar.css file at the bottom, using the 'move' cursor instead. try commenting out lines 98-100 and 103-107 and commenting IN lines 111-114